### PR TITLE
Allow creating or updating of One2many fields

### DIFF
--- a/src/flask_odoo/model.py
+++ b/src/flask_odoo/model.py
@@ -1,6 +1,6 @@
 import schematics
 
-from .types import One2manyType, Many2oneType
+from .types import Many2oneType
 
 
 def _model_name(cls):
@@ -64,9 +64,7 @@ def create_or_update(self):
     vals.pop("id", None)
     for name, field in self._schema.fields.items():
         key = field.serialized_name or name
-        if isinstance(field, schematics.types.Serializable) or isinstance(
-            field, One2manyType
-        ):
+        if isinstance(field, schematics.types.Serializable):
             vals.pop(key, None)
         elif isinstance(field, Many2oneType):
             if key in vals:

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -222,7 +222,7 @@ def test_base_model_create_or_update_no_serializable(app, app_context):
     )
 
 
-def test_base_model_create_or_update_no_one2many(app, app_context):
+def test_base_model_create_or_update_one2many(app, app_context):
     odoo = Odoo(app)
     app_context.odoo_common = MagicMock()
     app_context.odoo_common.authenticate.return_value = 1
@@ -244,7 +244,7 @@ def test_base_model_create_or_update_no_one2many(app, app_context):
         "admin",
         "res.partner",
         "create",
-        ({"name": "test_partner"},),
+        ({"name": "test_partner", "related_model_ids": [1, 2, 3]},),
         {},
     )
 


### PR DESCRIPTION
To be honest I don't remember why we added this restriction. I found no good reason to keep it.